### PR TITLE
Rework trim_spell_name and findSpellNode logic

### DIFF
--- a/campaign/scripts/char_invlist_ACIM.lua
+++ b/campaign/scripts/char_invlist_ACIM.lua
@@ -65,8 +65,9 @@ local function getSpellFromItemName(sItemName)
 	end
 
 	local function findSpellNode(sSpellName)
-		if DB.findNode('spelldesc.' .. sSpellName .. '@*') then
-			return DB.findNode('spelldesc.' .. sSpellName .. '@*');
+		local nodeRAWFormat = DB.findNode('spelldesc.' .. sSpellName .. '@*');
+		if nodeRAWFormat then
+			return nodeRAWFormat;
 		end
 
 		getLoadedModules();

--- a/campaign/scripts/char_invlist_ACIM.lua
+++ b/campaign/scripts/char_invlist_ACIM.lua
@@ -65,16 +65,17 @@ local function getSpellFromItemName(sItemName)
 	end
 
 	local function findSpellNode(sSpellName)
+		if DB.findNode('spelldesc.' .. sSpellName .. '@*') then
+			return DB.findNode('spelldesc.' .. sSpellName .. '@*');
+		end
+
 		getLoadedModules();
 		for _,sModuleName in ipairs(tLoadedModules) do
-			local nodeSpellModule = DB.findNode("spelldesc" .. "@" .. sModuleName);
-			if nodeSpellModule == nil then
-				nodeSpellModule = DB.findNode("reference.spells" .. "@" .. sModuleName);
-			end
+			local nodeSpellModule = DB.findNode('reference.spells' .. '@' .. sModuleName);
 			if nodeSpellModule then
 				for _,nodeSpell in pairs(nodeSpellModule.getChildren()) do
-					local sModuleSpellName = DB.getValue(nodeSpell, "name", "");
-					if sModuleSpellName ~= "" then
+					local sModuleSpellName = DB.getValue(nodeSpell, 'name', '');
+					if sModuleSpellName ~= '' then
 						if trim_spell_name(sModuleSpellName) == sSpellName then
 							return nodeSpell;
 						end

--- a/campaign/scripts/char_invlist_ACIM.lua
+++ b/campaign/scripts/char_invlist_ACIM.lua
@@ -90,7 +90,18 @@ local function getSpellFromItemName(sItemName)
 		local string_spell_name = sItemName:match('%b()');
 		if string_spell_name then
 			string_spell_name = string_spell_name:sub(2, -2);
-			string_spell_name = trim_spell_name(string_spell_name)
+			string_spell_name = trim_spell_name(string_spell_name);
+
+			return string_spell_name
+		end
+	end
+
+	local function getSpellAfterOf()
+		sItemName = sItemName:gsub('%[.+%]', '')
+		local _, j = sItemName:find('of ');
+		if j ~= nil then
+			local string_spell_name = sItemName:sub(j);
+			string_spell_name = trim_spell_name(string_spell_name);
 
 			return string_spell_name
 		end
@@ -100,6 +111,8 @@ local function getSpellFromItemName(sItemName)
 		local sSpellName = getSpellBetweenParenthesis();
 		if sSpellName then
 			return findSpellNode(sSpellName);
+		else
+			return findSpellNode(getSpellAfterOf())
 		end
 	end
 end

--- a/campaign/scripts/char_invlist_ACIM.lua
+++ b/campaign/scripts/char_invlist_ACIM.lua
@@ -35,7 +35,7 @@ local function usingExt(sExt) return StringManager.contains(Extension.getExtensi
 
 function getSpellSet(nodeChar, sItemSource)
 	if nodeChar and sItemSource ~= '' then
-		-- Debug.chat("getSpellSet", "sItemSource", sItemSource);
+		-- Debug.chat('getSpellSet', 'sItemSource', sItemSource);
 		for _, nodeSpellSet in pairs(DB.getChildren(nodeChar, _sSpellset)) do
 			-- Debug.chat(sItemSource, nodeSpellSet);
 			if DB.getValue(nodeSpellSet, 'source_name') == sItemSource then return nodeSpellSet; end
@@ -45,7 +45,10 @@ end
 
 local function trim_spell_name(string_spell_name)
 	string_spell_name = string_spell_name:lower();
-	string_spell_name = string_spell_name:gsub("%W", "");
+	-- check for potentional double brackets like in 'wand (magic missile (3rd))'
+	string_spell_name = string_spell_name:gsub('%b()', '')
+	string_spell_name = string_spell_name:gsub('%W', '');
+	string_spell_name = string_spell_name:gsub('heightened', '');
 
 	return string_spell_name
 end
@@ -215,9 +218,9 @@ local function getUsesAvailable(nodeItem, bWand)
 					if (nFieldCharges < nNameCharges) then return nFieldCharges; end
 				elseif usingExt('FG-PFRPG-Enhanced-Items') and (nNameCharges and (nFieldCharges == 0)) then
 					DB.removeHandler('charsheet.*.inventorylist.*.charge', 'onUpdate', onItemChanged)
-					DB.setValue(nodeItem, 'charge', 'number', nNameCharges); -- write charges from name to database node "charge"
+					DB.setValue(nodeItem, 'charge', 'number', nNameCharges); -- write charges from name to database node 'charge'
 					sName = sName:gsub(sCharges, ''):gsub('%[%]', ''); -- trim charges from name
-					DB.setValue(nodeItem, 'name', 'string', StringManager.trim(sName)); -- write trimmed name back to database node "name"
+					DB.setValue(nodeItem, 'name', 'string', StringManager.trim(sName)); -- write trimmed name back to database node 'name'
 					DB.addHandler('charsheet.*.inventorylist.*.charge', 'onUpdate', onItemChanged)
 					return nNameCharges;
 				else
@@ -299,7 +302,7 @@ function inventoryChanged(nodeChar, nodeItem, nodeTrigger)
 		if sCL then
 			local nNameCL = tonumber(sCL);
 			if nNameCL then
-				DB.setValue(nodeItem, 'cl', 'number', nNameCL); -- write CL from name to database node "cl"
+				DB.setValue(nodeItem, 'cl', 'number', nNameCL); -- write CL from name to database node 'cl'
 			end
 			return nNameCL or nCL;
 		end


### PR DESCRIPTION
- This generalises the spell finding and should be compatible with all exported modules and all bought modules unlike before.
- The trimming was generalized to substitute everything but alphanumerical letters because we now compare the actual name values. There might be some special written spells which are not detected. If you find some, let me know and I can patch that.

I've used nearly the same code for my 3.5e campaign. I would be glad, if you could test it with the PFRPG Spellbook :)